### PR TITLE
Add a raise error option not to suppress errors

### DIFF
--- a/launchable/plugin.py
+++ b/launchable/plugin.py
@@ -16,7 +16,7 @@ class Launchable(Plugin):
     # Grab stdout before the capture plugin
     score = Capture.score + 1
 
-    RAISE_ERROR_KEY = "LAUNCHABLE_RAISE_ERROR"
+    REPORT_ERROR_KEY = "LAUNCHABLE_REPORT_ERROR"
 
     def __init__(self):
         super().__init__()
@@ -47,7 +47,7 @@ class Launchable(Plugin):
             self._print("Test execution optimized by Launchable 🚀")
             return
         except Exception as e:
-            if os.getenv(self.RAISE_ERROR_KEY):
+            if os.getenv(self.REPORT_ERROR_KEY):
                 raise e
 
             logger.warning("An unexpected error occurred while optimizing test execution. "

--- a/launchable/plugin.py
+++ b/launchable/plugin.py
@@ -1,4 +1,5 @@
 
+import os
 import sys
 import traceback
 
@@ -14,6 +15,8 @@ class Launchable(Plugin):
     name = "launchable"
     # Grab stdout before the capture plugin
     score = Capture.score + 1
+
+    RAISE_ERROR_KEY = "LAUNCHABLE_RAISE_ERROR"
 
     def __init__(self):
         super().__init__()
@@ -43,7 +46,10 @@ class Launchable(Plugin):
 
             self._print("Test execution optimized by Launchable 🚀")
             return
-        except Exception:
+        except Exception as e:
+            if os.getenv(self.RAISE_ERROR_KEY):
+                raise e
+
             logger.warning("An unexpected error occurred while optimizing test execution. "
                            "Please enable debugging by setting a `LAUNCHABLE_DEBUG=1` environment variable "
                            "and send the logs to Launchable team. "


### PR DESCRIPTION
## Overview

Add a new option not to suppress errors when running a nose-launchable plugin. If you set `LAUNCHABLE_RAISE_ERROR` environment variable, errors are not suppressed.

### Without `LAUNCHABLE_RAISE_ERROR`
Even if a KeyError occurred, the test does not stop.

```
KeyError: 'LAUNCHABLE_TOKEN'

test1.func_tests(1,) ... func_test1
ok
test1.func_tests(2,) ... func_test2
ok
test1.func_tests(3,) ... func_test3
ok
test1.func_tests(4,) ... func_test4
ok
test1.func_tests(5,) ... func_test5
ok

----------------------------------------------------------------------
Ran 5 tests in 0.001s

OK
```

### With `LAUNCHABLE_RAISE_ERROR`
The test execution stops when it encounters an error

```
    raise KeyError(key) from None
KeyError: 'LAUNCHABLE_TOKEN'
```

