### PR TITLE
Use a unique module name for the inference

### DIFF
--- a/launchable/manager.py
+++ b/launchable/manager.py
@@ -1,7 +1,9 @@
+import os
 from types import ModuleType
 
 from nose.failure import Failure
 from nose.suite import ContextSuite
+from nose.util import test_address
 
 from launchable.log import logger
 
@@ -105,8 +107,8 @@ def _get_test_name(suite):
     if not _is_leaf(suite):
         raise RuntimeError("_get_test_name method should run only against a leaf. suite: {}".format(suite))
 
-    if isinstance(suite.context, ModuleType):
-        return suite.context.__name__
+    if suite.context is Failure:
+        return "failure"
 
-    # context is a class
-    return suite.context.__module__
+    file_path, module, _ = test_address(suite.context)
+    return "#".join([os.path.relpath(file_path), module])

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -21,14 +21,14 @@ class TestManager(unittest.TestCase):
                     'id': str(id(self.mock_suite0)),
                     'children':
                         [
-                            {'type': 'testCaseNode', 'testName': 'tests.resources.module0'},
+                            {'type': 'testCaseNode', 'testName': 'tests/resources/module0.py#tests.resources.module0'},
                             {
                                 'type': 'treeNode',
                                 'id': str(id(self.mock_suite1)),
                                 'children':
                                     [
-                                        {'type': 'testCaseNode', 'testName': 'tests.resources.module1'},
-                                        {'type': 'testCaseNode', 'testName': 'tests.resources.module2'}
+                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module1.py#tests.resources.module1'},
+                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module2.py#tests.resources.module2'}
                                     ],
                             }
                         ],
@@ -56,14 +56,14 @@ class TestManager(unittest.TestCase):
                     'id': str(id(self.mock_suite0)),
                     'children':
                         [
-                            {'type': 'testCaseNode', 'testName': 'tests.resources.module0'},
+                            {'type': 'testCaseNode', 'testName': 'tests/resources/module0.py#tests.resources.module0'},
                             {
                                 'type': 'treeNode',
                                 'id': str(id(self.mock_suite1)),
                                 'children':
                                     [
-                                        {'type': 'testCaseNode', 'testName': 'tests.resources.module1'},
-                                        {'type': 'testCaseNode', 'testName': 'tests.resources.module2'}
+                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module1.py#tests.resources.module1'},
+                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module2.py#tests.resources.module2'}
                                     ],
                             }
                         ],


### PR DESCRIPTION
Right now we use a module name as a testName for inference but depending on a file structure module name can be duplicated. As a result, when reordering, one test case may override others. Ref: https://github.com/launchableinc/nose-launchable/blob/main/launchable/manager.py#L65

In order to avoid that, I'll use a `relative_file_path#module_name` when inferencing.