### PR TITLE
Fix a testName for generator tests

### DIFF
--- a/launchable/manager.py
+++ b/launchable/manager.py
@@ -110,5 +110,5 @@ def _get_test_name(suite):
     if suite.context is Failure:
         return "failure"
 
-    file_path, module, _ = test_address(suite.context)
-    return "#".join([os.path.relpath(file_path), module])
+    file_path, _, _ = test_address(suite.context)
+    return os.path.relpath(file_path)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -21,14 +21,14 @@ class TestManager(unittest.TestCase):
                     'id': str(id(self.mock_suite0)),
                     'children':
                         [
-                            {'type': 'testCaseNode', 'testName': 'tests/resources/module0.py#tests.resources.module0'},
+                            {'type': 'testCaseNode', 'testName': 'tests/resources/module0.py'},
                             {
                                 'type': 'treeNode',
                                 'id': str(id(self.mock_suite1)),
                                 'children':
                                     [
-                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module1.py#tests.resources.module1'},
-                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module2.py#tests.resources.module2'}
+                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module1.py'},
+                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module2.py'}
                                     ],
                             }
                         ],
@@ -56,14 +56,14 @@ class TestManager(unittest.TestCase):
                     'id': str(id(self.mock_suite0)),
                     'children':
                         [
-                            {'type': 'testCaseNode', 'testName': 'tests/resources/module0.py#tests.resources.module0'},
+                            {'type': 'testCaseNode', 'testName': 'tests/resources/module0.py'},
                             {
                                 'type': 'treeNode',
                                 'id': str(id(self.mock_suite1)),
                                 'children':
                                     [
-                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module1.py#tests.resources.module1'},
-                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module2.py#tests.resources.module2'}
+                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module1.py'},
+                                        {'type': 'testCaseNode', 'testName': 'tests/resources/module2.py'}
                                     ],
                             }
                         ],


### PR DESCRIPTION
Right now, we blindly split a test id with `.` like below:

```
ids = t.test.id().split(".")
```

but it does not work if a generator test's argument contains `.`. For example:

```
def test_evens():
    for s in ["0.0", "1.0", "2.0"]:
        yield check_true, s


def check_true(s):
    assert s == s
```

[The xunit plugin handles the problem using a regular expression](https://github.com/nose-devs/nose/blob/master/nose/plugins/xunit.py#L66) so let's use it for nose-launchable too.