### PR TITLE
Add record-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ $ pip install nose-launchable
 $ nosetests --launchable-subset --launchable-build-number <build number> --launchable-subset-target <target percentage>
 ```
 
-In addition to specifying the `--launchable-subset` flag, you may need to set the following environment variables in your environment. These values should be provided from Launchable.
+### Record only
+
+```
+$ nosetests --launchable-record-only --launchable-build-number <build number>
+```
+
+In addition, you may need to set the following environment variables in your environment. These values should be provided from Launchable.
 
 |  Key  |  Description  |
 | ---- | ---- |

--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,15 @@ Subset
 
    $ nosetests --launchable-subset --launchable-build-number <build number> --launchable-subset-target <target percentage>
 
-In addition to specifying the ``--launchable-subset`` flag, you may need
-to set the following environment variables in your environment. These
-values should be provided from Launchable.
+Record only
+~~~~~~~~~~~
+
+::
+
+   $ nosetests --launchable-record-only --launchable-build-number <build number>
+
+In addition, you may need to set the following environment variables in
+your environment. These values should be provided from Launchable.
 
 +-----------------------------------+-----------------------------------+
 | Key                               | Description                       |


### PR DESCRIPTION
Newly added the `read-only` mode to the plugin, which only uploads test results to the Launchable server.