### PR TITLE
[ENG-89] Add launchable-subset-options flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ $ pip install nose-launchable
 ### Subset
 
 ```
-$ nosetests --launchable-subset --launchable-build-number <build number> --launchable-subset-target <target percentage>
+$ nosetests --launchable-subset --launchable-build-number <build number> --launchable-subset-options <Launchable CLI subset options>
 ```
+
+You need to specify `--launchable-subset-options` flag and give it Launchable CLI subset command options. For example, if you want to create a fixed time-based subset it looks like `--launchable-subset-options '--time 600'`. 
+
+For more information on the CLI options, please visit [the CLI documentation page](https://docs.launchableinc.com/resources/cli-reference#subset).
 
 ### Record only
 

--- a/nose_launchable/client.py
+++ b/nose_launchable/client.py
@@ -64,11 +64,20 @@ class LaunchableClient:
 
         self.test_session_id = response_body['id']
 
-    def subset(self, test_names, target):
+    def subset(self, test_names, options, target):
         url = "/test_sessions/{}".format(self.test_session_id)
 
+        cmd = ['launchable', 'subset', '--session', url]
+        if options is not None:
+            cmd.extend([option.strip() for option in options.split(' ')])
+            cmd.append('file')
+        else:
+            cmd.extend(['--target', target + '%', 'file'])
+
+        logger.debug("Subset command: {}".format(cmd))
+
         proc = self.process.run(
-            ['launchable', 'subset', '--session', url, '--target', target + '%', 'file'],
+            cmd,
             input="\n".join(test_names),
             encoding='utf-8',
             stdout=self.process.PIPE,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-launchable >= 1.5.5, ~= 1.0
+launchable >= 1.15.0, ~= 1.0
 nose>=1.0.0
 boto3>=1.0.0
 requests>=2.0.0


### PR DESCRIPTION
This PR defines a new flag called `launchable-subset-options` which is used to hand in Launchable CLI options directly from nose-launchable. With this change, customers can use the latest CLI options without defining new nose-launchable flags.