### PR TITLE
Improved the graceful fallback

### DIFF
--- a/nose_launchable/client.py
+++ b/nose_launchable/client.py
@@ -20,7 +20,7 @@ class LaunchableClientFactory:
 
     @classmethod
     def _parse_options(cls):
-        token = os.environ[cls.TOKEN_KEY]
+        token = os.environ.get(cls.TOKEN_KEY)
         if token is None:
             raise Exception("%s not set"%cls.TOKEN_KEY)
 

--- a/nose_launchable/client.py
+++ b/nose_launchable/client.py
@@ -21,6 +21,8 @@ class LaunchableClientFactory:
     @classmethod
     def _parse_options(cls):
         token = os.environ[cls.TOKEN_KEY]
+        if token is None:
+            raise Exception("%s not set"%cls.TOKEN_KEY)
 
         _, user, _ = token.split(":", 2)
         org, workplace = user.split("/", 1)

--- a/nose_launchable/plugin.py
+++ b/nose_launchable/plugin.py
@@ -59,7 +59,7 @@ class Launchable(Plugin):
             # we didn't get activated
             return
 
-        if os.environ[LaunchableClientFactory.TOKEN_KEY] is None:
+        if os.environ.get(LaunchableClientFactory.TOKEN_KEY) is None:
             logger.warning("%s not set. Deactivating"%LaunchableClientFactory.TOKEN_KEY)
             return
 

--- a/nose_launchable/plugin.py
+++ b/nose_launchable/plugin.py
@@ -11,7 +11,7 @@ from nose_launchable.case_event import CaseEvent
 from nose_launchable.client import LaunchableClientFactory
 from nose_launchable.log import logger
 from nose_launchable.manager import get_test_names, subset, get_test_path
-from nose_launchable.protecter import protect
+from nose_launchable.protecter import protect, handleError
 from nose_launchable.uploader import UploaderFactory
 
 BUILD_NUMBER_KEY = "LAUNCHABLE_BUILD_NUMBER"
@@ -25,9 +25,6 @@ class Launchable(Plugin):
 
     def __init__(self):
         super().__init__()
-
-        self._client = LaunchableClientFactory.prepare()
-        self._uploader = UploaderFactory.prepare(self._client)
 
         self._capture_stack = []
         self._currentStdout = None
@@ -52,30 +49,42 @@ class Launchable(Plugin):
         super(Launchable, self).configure(options, conf)
 
         self.subset_enabled = options.subset_enabled or False
-        self.build_number = options.build_number or os.getenv(BUILD_NUMBER_KEY)
-        self.subset_target = options.subset_target
-
-        self.subset_options = options.subset_options
-
         self.record_only_enabled = options.record_only_enabled or False
 
+        self.build_number = options.build_number or os.getenv(BUILD_NUMBER_KEY)
+        self.subset_target = options.subset_target
+        self.subset_options = options.subset_options
+
         if not (self.subset_enabled or self.record_only_enabled):
+            # we didn't get activated
+            return
+
+        if os.environ[LaunchableClientFactory.TOKEN_KEY] is None:
+            logger.warning("%s not set. Deactivating"%LaunchableClientFactory.TOKEN_KEY)
             return
 
         if self.subset_enabled and self.record_only_enabled:
-            self.enabled = False
             logger.warning("Please specify either --launchable-subset or --launchable-record-only flag")
             return
 
+        if self.build_number is None:
+            logger.warning("Please specify --launchable-build-number flag")
+            return
+
+        if not ((self.subset_target is None) ^ (self.subset_options is None)):
+            logger.warning("Please specify either --launchable-subset-target or --launchable-subset-options flag")
+            return
+
+        try:
+            self._client = LaunchableClientFactory.prepare()
+            self._uploader = UploaderFactory.prepare(self._client)
+        except Exception as e:
+            handleError(e)
+            return
+
+        # only if every validation checks out we are good to go
         self.enabled = True
 
-        if self.enabled and self.build_number is None:
-            self.enabled = False
-            logger.warning("Please specify --launchable-build-number flag")
-
-        if self.subset_enabled and not ((self.subset_target is None) ^ (self.subset_options is None)):
-            self.enabled = False
-            logger.warning("Please specify either --launchable-subset-target or --launchable-subset-options flag")
 
     @protect
     def begin(self):

--- a/nose_launchable/protecter.py
+++ b/nose_launchable/protecter.py
@@ -6,6 +6,15 @@ from nose_launchable.log import logger
 
 REPORT_ERROR_KEY = "LAUNCHABLE_REPORT_ERROR"
 
+def handleError(e):
+    if os.getenv(REPORT_ERROR_KEY) is not None:
+        raise e
+
+    logger.warning('An unexpected error occurred while optimizing test execution. Please enable debugging by '
+                   'setting a `LAUNCHABLE_DEBUG=1` environment variable and send the logs to Launchable team. '
+                   'Test execution starts in standard order.')
+    logger.warning(traceback.format_exc())
+
 
 def protect(f):
 
@@ -14,12 +23,6 @@ def protect(f):
         try:
             return f(*args, **kwargs)
         except Exception as e:
-            if os.getenv(REPORT_ERROR_KEY) is not None:
-                raise e
-
-            logger.warning('An unexpected error occurred while optimizing test execution. Please enable debugging by '
-                           'setting a `LAUNCHABLE_DEBUG=1` environment variable and send the logs to Launchable team. '
-                           'Test execution starts in standard order.')
-            logger.warning(traceback.format_exc())
+            handleError(e)
 
     return func


### PR DESCRIPTION
A customer reported that when the token is not set, we make nose fail hard. This shouldn't be.

This change makes that behaviour more graceful.

```
  File "/usr/lib/python3/dist-packages/nose/config.py", line 590, in getParser
    self.plugins.loadPlugins()
  File "/usr/lib/python3/dist-packages/nose/plugins/manager.py", line 400, in loadPlugins
    plug = plugcls()
  File "/mtee-env/lib/python3.7/site-packages/nose_launchable/plugin.py", line 29, in __init__
    self._client = LaunchableClientFactory.prepare()
  File "/mtee-env/lib/python3.7/site-packages/nose_launchable/client.py", line 17, in prepare
    url, org, wp, token = cls._parse_options()
  File "/mtee-env/lib/python3.7/site-packages/nose_launchable/client.py", line 25, in _parse_options
    _, user, _ = token.split(":", 2)
```