### PR TITLE
Disable reordering when subsetting

### DIFF
--- a/nose_launchable/plugin.py
+++ b/nose_launchable/plugin.py
@@ -150,10 +150,9 @@ class Launchable(Plugin):
     def _subset(self, test):
         test_names = get_test_names(test)
 
-        order = self._client.subset(test_names, self.subset_options, self.subset_target)
+        targets = self._client.subset(test_names, self.subset_options, self.subset_target)
 
-        # Create a dictionary maps test_name to its index
-        subset(test, {o: i for i, o in enumerate(order)})
+        subset(test, set(targets))
 
     def _startCapture(self):
         self._capture_stack.append((sys.stdout, sys.stderr))

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -28,17 +28,17 @@ class TestManager(unittest.TestCase):
         self.assertEqual(want, got)
 
     def test_subset_full(self):
-        want = ['tests/resources/module2.py', 'tests/resources/module1.py', 'tests/resources/module0.py']
+        want = ['tests/resources/module0.py', 'tests/resources/module1.py', 'tests/resources/module2.py']
 
-        subset(self.mock_suite0, {w: i for i, w in enumerate(want)})
+        subset(self.mock_suite0, set(want))
 
         got = get_test_names(self.mock_suite0)
         self.assertEqual(want, got)
 
     def test_subset_partial(self):
-        want = ['tests/resources/module2.py', 'tests/resources/module0.py']
+        want = ['tests/resources/module0.py', 'tests/resources/module2.py']
 
-        subset(self.mock_suite0, {w: i for i, w in enumerate(want)})
+        subset(self.mock_suite0, set(want))
 
         got = get_test_names(self.mock_suite0)
         self.assertEqual(want, got)
@@ -46,7 +46,7 @@ class TestManager(unittest.TestCase):
     def test_subset_empty(self):
         want = []
 
-        subset(self.mock_suite0, {w: i for i, w in enumerate(want)})
+        subset(self.mock_suite0, set(want))
 
         got = get_test_names(self.mock_suite0)
         self.assertEqual(want, got)


### PR DESCRIPTION
We used to reorder tests even when subsetting but this breaks our customers' test environment. To avoid that, we disabled reordering when subsetting.