### PR TITLE
Remove empty files from a subset request

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -4,13 +4,15 @@ from .resources.module1 import MockTestClass1
 from .resources.module2 import MockTestClass2
 
 from nose.suite import ContextSuite
+from nose.suite import Test
 from nose_launchable.manager import get_test_names, subset
 
 
 class TestManager(unittest.TestCase):
     def setUp(self):
-        self.mock_suite1 = ContextSuite(tests=[ContextSuite(context=MockTestClass1), ContextSuite(context=MockTestClass2)])
-        self.mock_suite0 = ContextSuite(tests=[ContextSuite(context=MockTestClass0), self.mock_suite1])
+        func = lambda: print("called")
+        self.mock_suite1 = ContextSuite(tests=[ContextSuite(tests=[Test(func)], context=MockTestClass1), ContextSuite(tests=[Test(func)], context=MockTestClass2)])
+        self.mock_suite0 = ContextSuite(tests=[ContextSuite(tests=[Test(func)], context=MockTestClass0), self.mock_suite1])
 
     def test_get_test_names(self):
         want = ['tests/resources/module0.py', 'tests/resources/module1.py', 'tests/resources/module2.py']


### PR DESCRIPTION
The current implementation sends contains test files to the subset endpoint even if it does not contain any tests. This is problematic especially when a user uses wantFunction/wantMethod interfaces to choose tests dynamically. For example, the Attrib plugin uses the interfaces and removes some tests.

To avoid that, I implemented the `is_empty` method which checks if a test file contains any test functions (or methods) recursively. With that change, the nose-launchable stop sending those empty test files to the subset endpoint.