### PR TITLE
[ENG-231] Stop parsing the test tree when reaching a method

### DIFF
--- a/nose_launchable/manager.py
+++ b/nose_launchable/manager.py
@@ -1,5 +1,5 @@
 import os
-from types import FunctionType
+from inspect import isfunction, ismethod
 from types import ModuleType
 
 from nose.case import Test
@@ -45,11 +45,12 @@ def is_empty(test):
         if not empty:
             return suite
 
-        # 1. If type(suite) is Test the search reaches at the bottom
-        # 2. If type(suite.context) is function, the test is a generator and stop parsing it there to avoid executing it
-        if type(suite) is Test or type(getattr(suite, "context", None)) is FunctionType:
+        context = getattr(suite, "context", None)
+        # 1. If type(suite) is Test, the search reaches at the bottom
+        # 2. If context is function or method, the search should stop there to avoid executing it.
+        #    It is most likely a test generator.
+        if type(suite) is Test or isfunction(context) or ismethod(context):
             empty = False
-
             return suite
 
         suite._tests = [dfs(t) for t in suite]


### PR DESCRIPTION
One of our customers reported an issue that nose-launchable didn't stop parsing tree when it reached a method and executed it when during prepareTest. To avoid that I added logic to stop parsing the tree when it reached a method. In addition, I slightly changed the code by replacing `type(getattr(suite, "context", None)) is FunctionType` with `inspect.isfunction`.