### PR TITLE
fix support skip test case

### DIFF
--- a/nose_launchable/case_event.py
+++ b/nose_launchable/case_event.py
@@ -5,6 +5,7 @@ class CaseEvent:
     EVENT_TYPE = "case"
     TEST_PASSED = 1
     TEST_FAILED = 0
+    TEST_SKIPPED = 2
 
     def __init__(self, test_path, duration, status, stdout, stderr):
         self.test_path = test_path


### PR DESCRIPTION
addSkip method in nose plugin is already deprecated ref: https://nose.readthedocs.io/en/latest/plugins/interface.html#nose.plugins.base.IPluginInterface.addSkip
And skipped tests will are called to an addError method. 
> Warning DEPRECATED – check error class in addError instead

So, I fixed to check error type and when the error is an unittest.caseSkipTest or a nose.plugin.skip.SkipTest, we report the test case as staus skipped.

If the user uses an old python, the type will be `unittest2.case.SkipTest`. But we don't support such an old python. I don't care it, for now.


- add skip status
- support skip test
