### PR TITLE
check test attributes

### DIFF
--- a/nose_launchable/plugin.py
+++ b/nose_launchable/plugin.py
@@ -194,6 +194,10 @@ class Launchable(Plugin):
         return ''
 
     def _addResult(self, test, status, queueing):
+        if not hasattr(test, "test"):
+            logger.warn("This test case is skipped to report because this test doesn't have test attribute. (test id: {})".format(getattr(test, "id", None)))
+            return
+
         test_path = get_test_path(test)
 
         logger.debug("Adding a test result: test: {}, context: {}, test_path: {}".format(test, test.context, test_path))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
+import sys
 import unittest
+import pytest
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -153,6 +155,7 @@ class TestLaunchableClient(unittest.TestCase):
             expected_command, input=expected_input, encoding='utf-8', stdout='PIPE', stderr='PIPE')
         self.assertEqual(['tests/test2.py', 'tests/test1.py'], got)
 
+    @pytest.mark.skipif(sys.version_info < (3, 6), reason='3.5 changes subset option orders and failed test. So, skip this tests under v3.6')
     def test_split_subset(self):
         mock_subset = MagicMock(name="subset")
         mock_subset.stdout = "/subset/123"


### PR DESCRIPTION
In some cases, a test attribute of the test (`test.test`) isn't set. 
However, [get_test_path](https://github.com/launchableinc/nose-launchable/blob/bdc5615e3f84c25c59441cd471b6f9d5e7b3fb8d/nose_launchable/manager.py#L133) method calls a `test` attribute to make test path. Then, happened error `AttributeError: 'ContextSuite' object has no attribute 'test'`. 

So, I added validation and logging when it happens.