### PR TITLE
Update nose3 to pynose

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 launchable >= 1.26.0, ~= 1.0
 nose>=1.0.0; python_version < '3.10'
-nose3>=1.3.8; python_version >= '3.10'
+pynose>=1.5.1; python_version >= '3.10'
 boto3>=1.0.0
 requests>=2.0.0


### PR DESCRIPTION
pynose can support python 3.11 and newer version. Change the package dependency from nose3 to pynose