### PR TITLE
Update nose3 to pynose

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 launchable >= 1.26.0, ~= 1.0
 nose>=1.0.0; python_version < '3.10'
-nose3>=1.3.8; python_version >= '3.10'
+pynose>=1.5.1; python_version >= '3.10'
 boto3>=1.0.0
 requests>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ nose>=1.0.0; python_version < '3.10'
 pynose>=1.5.1; python_version >= '3.10'
 boto3>=1.0.0
 requests>=2.0.0
+# https://github.com/GeneralMills/pytrends/issues/591
+urllib3<2


### PR DESCRIPTION
Because the secrets value couldn't load, the launchable command failed in https://github.com/launchableinc/nose-launchable/pull/71 

So, I cherry-picked the commit and updated support Python versions