### PR TITLE
update api token authentication

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,8 +25,8 @@ jobs:
         pip install setuptools wheel twine
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
PyPI requires API token authentication now when we publish to PyPI. So, issued a token and updated to use it

![image](https://github.com/launchableinc/nose-launchable/assets/536667/0c365aa8-a14e-4c6c-9cb5-2f28156e31b2)

